### PR TITLE
Add filter endpoint

### DIFF
--- a/src/parse/parse.controller.ts
+++ b/src/parse/parse.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common'
+import { Controller, Get, Param, Query } from '@nestjs/common'
 import { ParseService } from './parse.service'
 import { Tab, MediaResponse } from './types'
 
@@ -46,5 +46,16 @@ export class ParseController {
     @Get('/search/:name')
     async fetchSearch(@Param('name') name: string = 'panda'): Promise<MediaResponse> {
         return await this.parseService.fetchMedia(`https://uaserial.club/search?query=${name}`)
+    }
+
+    @Get('/filter')
+    async fetchFiltered(
+        @Query('mediaType') mediaType: string,
+        @Query('priority') priority: string,
+        @Query('rating') rating: string,
+        @Query('genre') genre: string,
+        @Query('date') date: string
+    ): Promise<MediaResponse> {
+        return await this.parseService.fetchFilteredMedia(mediaType, priority, rating, genre, date)
     }
 }

--- a/src/parse/parse.service.ts
+++ b/src/parse/parse.service.ts
@@ -72,4 +72,28 @@ export class ParseService {
             countOfPages: countOfPages,
         }
     }
+
+    async fetchFilteredMedia(
+        mediaType: string,
+        priority: string,
+        rating: string,
+        genre: string,
+        date: string
+    ): Promise<MediaResponse> {
+        const priorityParam = priority ? `&priority=${priority}` : ''
+        const ratingParam = rating ? `&rating=${rating}` : ''
+        const genreParam = genre ? `&genre=${genre}` : ''
+        const dateParam = date ? `&date=${date}` : ''
+        const mediaTypes = {
+            all: '',
+            movies: 'movie',
+            series: 'serial',
+            cartoons: 'cartoon-movie',
+            'cartoon-series': 'cartoon-series',
+            anime: 'anime',
+        }
+
+        const url = `https://uaserial.club/${mediaType ? mediaTypes[mediaType] : ''}?${priorityParam}${ratingParam}${genreParam}${dateParam}`
+        return await this.fetchMedia(url.replace('/?&', '/?'))
+    }
 }


### PR DESCRIPTION
Filter accepts these params:
- priority = popular | views | rating | date | added
- genre = biography & action & western & military & detective & documentary & dorams & drama & action-1 & historical & horrors & comedy & short-movies & kriminalnij & melodramy & adventure & romantychnyi & family & sport & thriller & fantasy & fantasy-1
- date = 2024 & 2023 & 2022 & 2021 & 2016-2019 & 2020 & 2010-2015 & 1800-2009
- rating = 0-10

'genre' and 'date' params accept multiple choises using '%2C' symbol as a separator. Example: 'genre=drama%2Cadventure%2Cbiography' or 'date=2024%2C2023'.

'rating' param accepts range of choises between 0 and 10 included separated by '-' symbol. Example: 'rating=0-9' or 'rating=6-10'